### PR TITLE
chore: Add support for Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+
+  unit:
+    name: unit
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+      - run: |
+          go test -race -timeout 240s ./...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing
+
+Thank you for considering making contributions to Amass! Start by taking a look at the [open issues](https://github.com/owasp-amass/asset-db/issues) for things we need help with!
+
+Please follow standard github best practices: fork the repo, branch from the tip of develop, make some commits, and submit a pull request to develop.
+
+Please make sure to use `gofmt` before every commit - the easiest way to do this is have your editor run it for you upon saving a file. Otherwise, run the following command in the project root directory: `go fmt ./...`
+
+## Forking
+
+Please note that Go requires code to live under absolute paths, which complicates forking.
+While the fork for user 'foo' lives at `https://github.com/foo/asset-db`,
+the code should never exist at  `$GOPATH/src/github.com/foo/asset-db`.
+Instead, we use `git remote` to add the fork as a new remote for the original repo,
+`$GOPATH/src/github.com/owasp-amass/asset-db`, and do all the work there.
+
+For instance, to create a fork and work on a branch of it, user 'foo' would:
+
+  * Create the fork on github, using the fork button.
+  * Go to the original repo checked out locally (ie. `$GOPATH/src/github.com/owasp-amass/asset-db`)
+  * `git remote rename origin upstream`
+  * `git remote add origin git@github.com:foo/asset-db.git`
+
+Now `origin` refers to the foo fork and `upstream` refers to the OWASP version.
+So foo can `git push -u origin master` to update his/her fork, and make pull requests to OWASP from there.
+Of course, replace `foo` with your git handle.
+
+To pull in updates from the original repo, run
+
+    * `git fetch upstream`
+    * `git rebase upstream/master` (or whatever branch you want)
+
+Please don't make Pull Requests to `master`.
+
+### Development Procedure:
+- the latest state of development is on `develop`
+- no --force onto `develop` (except when reverting a broken commit, which should seldom happen)
+- create a development branch on your fork (using `git add origin`)
+- before submitting a pull request, begin `git rebase` on top of `develop`

--- a/README.md
+++ b/README.md
@@ -8,15 +8,3 @@
 [![Follow on Twitter](https://img.shields.io/twitter/follow/owaspamass.svg?logo=twitter)](https://twitter.com/owaspamass)
 
 This repository offers services and repositories to interact with an asset database. It aims to foster the development of an ecosystem of scanning tools, allowing them to store assets (from [open-asset-model](https://github.com/owasp-amass/open-asset-model) and their relationships.
-
-## Documentation
-
-The documentation can be found in the Go packages repository: [asset-db](https://pkg.go.dev/github.com/owasp-amass/asset-db), there you can find the reference and descriptions to the available services.
-
-## Contributing
-
-We are always happy to get new contributors on board! Please check [CONTRIBUTING.md](CONTRIBUTING.md) to learn how to contribute to our codebase, and join our [Discord Server](https://discord.gg/HNePVyX3cp) to discuss current project goals.
-
-## Licensing
-
-This program is free software: you can redistribute it and/or modify it under the terms of the [Apache license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# asset-db
+
+[![GoDoc](https://pkg.go.dev/badge/github.com/owasp-amass/asset-db/?utm_source=godoc)](https://pkg.go.dev/github.com/owasp-amass/asset-db)
+[![License](https://img.shields.io/badge/license-apache%202-blue)](https://www.apache.org/licenses/LICENSE-2.0)
+[![Contribute Yes](https://img.shields.io/badge/contribute-yes-brightgreen.svg)](./CONTRIBUTING.md)
+
+[![Chat on Discord](https://img.shields.io/discord/433729817918308352.svg?logo=discord)](https://discord.gg/HNePVyX3cp)
+[![Follow on Twitter](https://img.shields.io/twitter/follow/owaspamass.svg?logo=twitter)](https://twitter.com/owaspamass)
+
+This repository offers services and repositories to interact with the attack surface database. It aims to foster the development of an ecosystem of scanning tools, allowing them to store results within the same datastore as Amass.
+
+## Documentation
+
+The documentation can be found in the Go packages repository: [asset-db](https://pkg.go.dev/github.com/owasp-amass/asset-db), there you can find the reference and descriptions to the available services.
+
+## Contributing
+
+We are always happy to get new contributors on board! Please check [CONTRIBUTING.md](CONTRIBUTING.md) to learn how to contribute to our codebase, and join our [Discord Server](https://discord.gg/HNePVyX3cp) to discuss current project goals.
+
+## Licensing
+
+This program is free software: you can redistribute it and/or modify it under the terms of the [Apache license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Chat on Discord](https://img.shields.io/discord/433729817918308352.svg?logo=discord)](https://discord.gg/HNePVyX3cp)
 [![Follow on Twitter](https://img.shields.io/twitter/follow/owaspamass.svg?logo=twitter)](https://twitter.com/owaspamass)
 
-This repository offers services and repositories to interact with the attack surface database. It aims to foster the development of an ecosystem of scanning tools, allowing them to store results within the same datastore as Amass.
+This repository offers services and repositories to interact with an asset database. It aims to foster the development of an ecosystem of scanning tools, allowing them to store assets (from [open-asset-model](https://github.com/owasp-amass/open-asset-model) and their relationships.
 
 ## Documentation
 

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,4 @@
+// A comprehensive service
+// for managing attack surface assets
+// and relations in the OWASP Amass ecosystem.
+package asset_db

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/owasp-amass/asset-db
+
+go 1.20


### PR DESCRIPTION
This PR introduces basic documentation for the asset-db repository and enables GitHub Actions for continuous integration.

The documentation provides an overview of the repository's purpose.