### PR TITLE
fix(migrations/sqlite)!: add default for sqlite asset/relation created_at

### DIFF
--- a/migrations/sqlite3/001_schema_init.sql
+++ b/migrations/sqlite3/001_schema_init.sql
@@ -5,13 +5,13 @@ PRAGMA foreign_keys = ON;
 
 CREATE TABLE IF NOT EXISTS assets(
     id INTEGER PRIMARY KEY,
-    created_at DATETIME,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     type TEXT,
     content TEXT);
 
 CREATE TABLE IF NOT EXISTS relations(
     id INTEGER PRIMARY KEY,
-    created_at DATETIME,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     type TEXT,
     from_asset_id INTEGER,
     to_asset_id INTEGER,


### PR DESCRIPTION
the init migration for sqllite did not specify a default for the created_at column in both `asset` and `relation` tables.

This adds this to the migration scripts to resolve this bug.