### PR TITLE
fix(migrations): relations last_seen_at index

### DIFF
--- a/migrations/postgres/006_relations_indexes.sql
+++ b/migrations/postgres/006_relations_indexes.sql
@@ -5,5 +5,5 @@ CREATE INDEX idx_rel_last_seen ON assets (last_seen);
 
 -- +migrate Down
 
-DROP INDEX idx_rel_created_at;
-DROP INDEX idx_rel_last_seen;
+DROP INDEX IF EXISTS idx_rel_created_at;
+DROP INDEX IF EXISTS idx_rel_last_seen;

--- a/migrations/postgres/007_relations_indexes.sql
+++ b/migrations/postgres/007_relations_indexes.sql
@@ -1,0 +1,8 @@
+-- +migrate Up
+
+DROP INDEX IF EXISTS idx_rel_last_seen;
+CREATE INDEX idx_rel_last_seen ON relations (last_seen);
+
+-- +migrate Down
+
+DROP INDEX IF EXISTS idx_rel_last_seen;

--- a/migrations/postgres/008_rel_type_idx.sql
+++ b/migrations/postgres/008_rel_type_idx.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+CREATE INDEX idx_rel_type ON relations (type);
+
+-- +migrate Down
+DROP INDEX IF EXISTS idx_rel_type;

--- a/migrations/sqlite3/006_rel_type_idx.sql
+++ b/migrations/sqlite3/006_rel_type_idx.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+CREATE INDEX idx_rel_type ON relations (type);
+
+-- +migrate Down
+DROP INDEX IF EXISTS idx_rel_type;


### PR DESCRIPTION
A previous migration (006) incorrectly associated the index with the assets table. This fix removes the previous index and creates a new one on the relations table

Closes #28