### PR TITLE
Patch 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:latest
+FROM postgres:16.4
 RUN mkdir -p /docker-entrypoint-initdb.d
 COPY ./initdb-assetdb.sh /docker-entrypoint-initdb.d/1_assetdb.sh
 RUN chmod +x /docker-entrypoint-initdb.d/1_assetdb.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:16.4
+FROM postgres:16
 RUN mkdir -p /docker-entrypoint-initdb.d
 COPY ./initdb-assetdb.sh /docker-entrypoint-initdb.d/1_assetdb.sh
 RUN chmod +x /docker-entrypoint-initdb.d/1_assetdb.sh


### PR DESCRIPTION
This forces Amass to use the PostgreSQL 16.4 docker image instead of "latest".  Latest pulls the psql 17 version as of 9/27/2024.  Psql 17 is incompatible with the directory structure and database files of psql 16 and thus breaks anyone who's been using the beta up to this point.